### PR TITLE
add Volume Label support to FUSE API

### DIFF
--- a/Contributors.asciidoc
+++ b/Contributors.asciidoc
@@ -54,5 +54,6 @@ This CONTRIBUTOR AGREEMENT applies to any contribution that you make to the WinF
 CONTRIBUTOR LIST
 ----------------
 |===
-|Bill Zissimopoulos                     |billziss at navimatics.com
+|Bill Zissimopoulos                                             |billziss at navimatics.com
+|Sam Kelly (DuroSoft Technologies LLC, https://durosoft.com)    |sam at durosoft.com
 |===

--- a/src/dll/fuse/fuse_intf.c
+++ b/src/dll/fuse/fuse_intf.c
@@ -646,8 +646,13 @@ static NTSTATUS fsp_fuse_intf_GetVolumeInfo(FSP_FILE_SYSTEM *FileSystem,
 
     VolumeInfo->TotalSize = (UINT64)stbuf.f_blocks * (UINT64)stbuf.f_frsize;
     VolumeInfo->FreeSize = (UINT64)stbuf.f_bfree * (UINT64)stbuf.f_frsize;
-    VolumeInfo->VolumeLabelLength = 0;
-    VolumeInfo->VolumeLabel[0] = L'\0';
+
+    memcpy(&VolumeInfo->VolumeLabel, &f->VolumeLabel, sizeof f->VolumeLabel);
+    int i;
+    for(i = 0; i < sizeof VolumeInfo->VolumeLabel; i++)
+        if(VolumeInfo->VolumeLabel[i] == L'\0')
+            break;
+    VolumeInfo->VolumeLabelLength = (UINT16)i;
 
     return STATUS_SUCCESS;
 }

--- a/src/dll/fuse/library.h
+++ b/src/dll/fuse/library.h
@@ -48,6 +48,7 @@ struct fuse
     PWSTR MountPoint;
     FSP_FILE_SYSTEM *FileSystem;
     FSP_SERVICE *Service; /* weak */
+    WCHAR VolumeLabel[32];
 };
 
 struct fsp_fuse_context_header


### PR DESCRIPTION
### Overview
Adds the ability to specify the volume label for a file system mounted via the FUSE API. While volume label is not part of the FUSE specification, this is a desirable feature on OSes such as Windows where it is possible to customize the volume label.

* This is already a feature in OSXFUSE, so we have matched the option they used (`"volname="`).
* also needed by https://github.com/DuroSoft/fuse-bindings, which intends to add support for setting a "volume name" across all supported platforms (windows/osx/linux)
* closes #64 

### Notes
* my windows dev environment is hosed at the moment, so have not been able to test yet
* I tried my best, where possible, to match the existing coding style / formatting, though my preference would be a bit different ;)