### PR TITLE
Don't decrease FileSize on write

### DIFF
--- a/Contributors.asciidoc
+++ b/Contributors.asciidoc
@@ -56,4 +56,5 @@ CONTRIBUTOR LIST
 |===
 |Bill Zissimopoulos                                             |billziss at navimatics.com
 |Sam Kelly (DuroSoft Technologies LLC, https://durosoft.com)    |sam at durosoft.com
+|Tobias Urlaub                                                  |saibotu at outlook.de
 |===

--- a/src/dll/fuse/fuse_intf.c
+++ b/src/dll/fuse/fuse_intf.c
@@ -1148,7 +1148,8 @@ static NTSTATUS fsp_fuse_intf_Write(FSP_FILE_SYSTEM *FileSystem,
 
     AllocationUnit = (UINT64)f->VolumeParams.SectorSize *
         (UINT64)f->VolumeParams.SectorsPerAllocationUnit;
-    FileInfoBuf.FileSize = Offset + bytes;
+    if (Offset + bytes > FileInfoBuf.FileSize)
+        FileInfoBuf.FileSize = Offset + bytes;
     FileInfoBuf.AllocationSize =
         (FileInfoBuf.FileSize + AllocationUnit - 1) / AllocationUnit * AllocationUnit;
 


### PR DESCRIPTION
This prevents decreasing the reported `FileSize`/`EndOfFile` when only part of a file is written, which fixes compatibility with various applications.