### PR TITLE
Speed up mount operation by putting winfsp network provider at the he…

### DIFF
--- a/src/dll/np.c
+++ b/src/dll/np.c
@@ -35,6 +35,12 @@
  */
 #define FSP_NP_CREDENTIAL_MANAGER
 
+/*
+ * Define the following macro to register ourselves as the first network provider.
+ * Otherwise we will be registered as the last network provider.
+ */
+#define FSP_NP_ORDER_FIRST
+
 enum
 {
     FSP_NP_CREDENTIALS_NONE             = 0,
@@ -1082,7 +1088,11 @@ NTSTATUS FspNpRegister(VOID)
         return FspNtStatusFromWin32(RegResult);
 
     RegBufferSize = sizeof RegBuffer - sizeof L"," FSP_NP_NAME;
-    RegBufferOffset = lstrlenW(L"," FSP_NP_NAME);
+#ifdef FSP_NP_ORDER_FIRST
+    RegBufferOffset = sizeof "" FSP_NP_NAME;
+#else
+    RegBufferOffset = 0;
+#endif
     RegResult = RegQueryValueExW(RegKey,
         L"ProviderOrder", 0, &RegType, (PVOID)&RegBuffer[RegBufferOffset], &RegBufferSize);
     if (ERROR_SUCCESS != RegResult)
@@ -1108,7 +1118,11 @@ NTSTATUS FspNpRegister(VOID)
 
     if (!FoundProvider)
     {
+#ifdef FSP_NP_ORDER_FIRST
         memcpy((PWSTR)RegBuffer, L"" FSP_NP_NAME ",", sizeof L"" FSP_NP_NAME);
+#else
+        memcpy(--P, L"," FSP_NP_NAME, sizeof L"," FSP_NP_NAME);
+#endif
 
         RegBufferSize = lstrlenW(RegBuffer);
         RegBufferSize++;


### PR DESCRIPTION
Hi @billziss-gh ,

This PR partially fixes #87 (which I'm experiencing as well).
The initial delay when mapping a network drive is gone with this fix.
In #87, you already mentioned putting the winfsp network provider entry at the beginning of the provider order instead of appending it. This PR does exactly that.
The other delays are unrelated (#87 actually is about two (or even more) different issues)
Tested on Win8.1

Cheers
 -Fritz

----

Before submitting this PR please review this checklist. Ideally all checkmarks should be checked upon submitting. (Use an x inside square brackets like so: [x])

- [x] **Contributing**: You MUST read and be willing to accept the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc). The agreement gives joint copyright interests in your contributions to you and the original WinFsp author. If you have already accepted the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc) you do not need to do so again.
- [x] **Topic branch**: Avoid creating the PR off the master branch of your fork. Consider creating a topic branch and request a pull from that. This allows you to add commits to the master branch of your fork without affecting this PR.
- [x] **No tabs**: Consistently use SPACES everywhere. NO TABS, unless the file format requires it (e.g. Makefile).
- [x] **Style**: Follow the same code style as the rest of the project.
- [N/A] **Tests**: Include tests to the extent that it is possible, especially if you add a new feature.
- [x] **Quality**: Your design and code should be of high quality and something that you are proud of.
