### PR TITLE
Fix #213 and a typo in macro FSP_FUSE_CTLCODE_FROM_IOCTL

### DIFF
--- a/inc/fuse/winfsp_fuse.h
+++ b/inc/fuse/winfsp_fuse.h
@@ -59,7 +59,7 @@ extern "C" {
 
 #define FSP_FUSE_DEVICE_TYPE            (0x8000 | 'W' | 'F' * 0x100) /* DeviceIoControl -> ioctl */
 #define FSP_FUSE_CTLCODE_FROM_IOCTL(cmd)\
-    (FSP_FUSE_DEVICE_TYPE << 16) | (((c) & 0x0fff) << 2)
+    (FSP_FUSE_DEVICE_TYPE << 16) | (((cmd) & 0x0fff) << 2)
 #define FSP_FUSE_IOCTL(cmd, isiz, osiz) \
     (                                   \
         (((osiz) != 0) << 31) |         \

--- a/src/dll/fuse/fuse_intf.c
+++ b/src/dll/fuse/fuse_intf.c
@@ -2168,6 +2168,7 @@ static NTSTATUS fsp_fuse_intf_Control(FSP_FILE_SYSTEM *FileSystem,
             memcpy(OutputBuffer, InputBuffer, InputBufferLength);
         err = f->ops.ioctl(filedesc->PosixPath, cmd, 0, &fi, 0, OutputBuffer);
     }
+    *PBytesTransferred = OutputBufferLength;
 
     return fsp_fuse_ntstatus_from_errno(f->env, err);
 }


### PR DESCRIPTION
This PR fixes Issue #213 as well a a typo in a macro which I found while staring at the code.
----

Please note: This PR is intentionally created against your release/1.4 branch because it is a pure bugfix.
Tests are WIP and will follow in a separate PR when I figured out your winfsp-tests framework
See [my WIP](https://github.com/felfert/winfsp/blob/passthrough-fuse-ioctl-test/tst/passthrough-fuse/).

Before submitting this PR please review this checklist. Ideally all checkmarks should be checked upon submitting. (Use an x inside square brackets like so: [x])

- [x] **Contributing**: You MUST read and be willing to accept the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc). The agreement gives joint copyright interests in your contributions to you and the original WinFsp author. If you have already accepted the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc) you do not need to do so again.
- [x] **Topic branch**: Avoid creating the PR off the master branch of your fork. Consider creating a topic branch and request a pull from that. This allows you to add commits to the master branch of your fork without affecting this PR.
- [x] **No tabs**: Consistently use SPACES everywhere. NO TABS, unless the file format requires it (e.g. Makefile).
- [x] **Style**: Follow the same code style as the rest of the project.
- [ ] **Tests**: Include tests to the extent that it is possible, especially if you add a new feature.
- [x] **Quality**: Your design and code should be of high quality and something that you are proud of.
