### PR TITLE
Make FlushAndPurgeOnCleanup accessible in C++

### DIFF
--- a/Contributors.asciidoc
+++ b/Contributors.asciidoc
@@ -56,6 +56,7 @@ CONTRIBUTOR LIST
 |===
 |Ben Rubson                                                     |ben.rubson at gmail.com
 |Bill Zissimopoulos                                             |billziss at navimatics.com
+|Colin Atkinson (Atakama, https://atakama.com)                  |colin at atakama.com
 |Francois Karam (KS2, http://www.ks2.fr)                        |francois.karam at ks2.fr
 |Fritz Elfert                                                   |fritz-github at fritz-elfert.de
 |John Oberschelp                                                |john at oberschelp.net

--- a/inc/winfsp/winfsp.hpp
+++ b/inc/winfsp/winfsp.hpp
@@ -612,6 +612,14 @@ public:
     {
         _VolumeParams.PassQueryDirectoryPattern = !!PassQueryDirectoryPattern;
     }
+    BOOLEAN FlushAndPurgeOnCleanup()
+    {
+        return _VolumeParams.FlushAndPurgeOnCleanup;
+    }
+    VOID SetFlushAndPurgeOnCleanup(BOOLEAN FlushAndPurgeOnCleanup)
+    {
+        _VolumeParams.FlushAndPurgeOnCleanup = !!FlushAndPurgeOnCleanup;
+    }
     PWSTR Prefix()
     {
         return _VolumeParams.Prefix;

--- a/tst/passthrough-cpp/passthrough-cpp.cpp
+++ b/tst/passthrough-cpp/passthrough-cpp.cpp
@@ -268,6 +268,7 @@ NTSTATUS Ptfs::Init(PVOID Host0)
     Host->SetPassQueryDirectoryPattern(TRUE);
     Host->SetVolumeCreationTime(_CreationTime);
     Host->SetVolumeSerialNumber(0);
+    Host->SetFlushAndPurgeOnCleanup(TRUE);
     return STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
I was running into the same issue as #206, and realized this option wasn't accessible via the C++ bindings. I also went ahead and set this option to `TRUE` in the passthrough-cpp system, in order to better align with the behavior of the C passthrough.

----

Before submitting this PR please review this checklist. Ideally all checkmarks should be checked upon submitting. (Use an x inside square brackets like so: [x])

- [x] **Contributing**: You MUST read and be willing to accept the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc). The agreement gives joint copyright interests in your contributions to you and the original WinFsp author. If you have already accepted the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc) you do not need to do so again.
- [x] **Topic branch**: Avoid creating the PR off the master branch of your fork. Consider creating a topic branch and request a pull from that. This allows you to add commits to the master branch of your fork without affecting this PR.
- [x] **No tabs**: Consistently use SPACES everywhere. NO TABS, unless the file format requires it (e.g. Makefile).
- [x] **Style**: Follow the same code style as the rest of the project.
- [x] **Tests**: Include tests to the extent that it is possible, especially if you add a new feature.
- [x] **Quality**: Your design and code should be of high quality and something that you are proud of.
