### PR TITLE
Fix read corruption issue.

### DIFF
--- a/Contributors.asciidoc
+++ b/Contributors.asciidoc
@@ -57,6 +57,7 @@ CONTRIBUTOR LIST
 |Ben Rubson                                                     |ben.rubson at gmail.com
 |Bill Zissimopoulos                                             |billziss at navimatics.com
 |Colin Atkinson (Atakama, https://atakama.com)                  |colin at atakama.com
+|Felix Croes                                                    |felix at dworkin.nl
 |Francois Karam (KS2, http://www.ks2.fr)                        |francois.karam at ks2.fr
 |Fritz Elfert                                                   |fritz-github at fritz-elfert.de
 |John Oberschelp                                                |john at oberschelp.net

--- a/src/sys/read.c
+++ b/src/sys/read.c
@@ -150,7 +150,7 @@ static NTSTATUS FspFsvolReadCached(
         FspFileNodeRelease(FileNode, Main);
         return STATUS_END_OF_FILE;
     }
-    if (ReadLength > (ULONG)(FileInfo.FileSize - ReadOffset.QuadPart))
+    if ((UINT64)ReadLength > FileInfo.FileSize - ReadOffset.QuadPart)
         ReadLength = (ULONG)(FileInfo.FileSize - ReadOffset.QuadPart);
 
     /* initialize cache if not already initialized! */


### PR DESCRIPTION
See https://github.com/billziss-gh/winfsp/issues/218

Presumably, a warning was silenced using the wrong cast.