### PR TITLE
Remove "FUSE-" prefix from file system name when using FUSE API

### DIFF
--- a/Contributors.asciidoc
+++ b/Contributors.asciidoc
@@ -61,6 +61,7 @@ CONTRIBUTOR LIST
 |Francois Karam (KS2, http://www.ks2.fr)                        |francois.karam at ks2.fr
 |Fritz Elfert                                                   |fritz-github at fritz-elfert.de
 |John Oberschelp                                                |john at oberschelp.net
+|John Tyner                                                     |jtyner at gmail.com
 |Sam Kelly (DuroSoft Technologies LLC, https://durosoft.com)    |sam at durosoft.com
 |Santiago Ganis                                                 |sganis at gmail.com
 |Tobias Urlaub                                                  |saibotu at outlook.de

--- a/src/dll/fuse/fuse.c
+++ b/src/dll/fuse/fuse.c
@@ -102,6 +102,8 @@ static struct fuse_opt fsp_fuse_core_opts[] =
     FUSE_OPT_KEY("--VolumePrefix=", 'U'),
     FUSE_OPT_KEY("FileSystemName=", 'F'),
     FUSE_OPT_KEY("--FileSystemName=", 'F'),
+    FUSE_OPT_KEY("ExactFileSystemName=", 'E'),
+    FUSE_OPT_KEY("--ExactFileSystemName=", 'E'),
 
     FSP_FUSE_CORE_OPT("UserName=", set_uid, 1),
     FUSE_OPT_KEY("UserName=", 'u'),
@@ -366,6 +368,18 @@ static int fsp_fuse_core_opt_proc(void *opt_data0, const char *arg, int key,
         opt_data->VolumeParams.FileSystemName
             [sizeof opt_data->VolumeParams.FileSystemName / sizeof(WCHAR) - 1] = L'\0';
         memcpy(opt_data->VolumeParams.FileSystemName, L"FUSE-", 5 * sizeof(WCHAR));
+        return 0;
+    case 'E':
+        if ('E' == arg[0])
+            arg += sizeof "ExactFileSystemName=" - 1;
+        else if ('E' == arg[2])
+            arg += sizeof "--ExactFileSystemName=" - 1;
+        if (0 == MultiByteToWideChar(CP_UTF8, 0, arg, -1,
+            opt_data->VolumeParams.FileSystemName,
+            sizeof opt_data->VolumeParams.FileSystemName / sizeof(WCHAR)))
+            return -1;
+        opt_data->VolumeParams.FileSystemName
+            [sizeof opt_data->VolumeParams.FileSystemName / sizeof(WCHAR) - 1] = L'\0';
         return 0;
     case 'u':
         if ('U' == arg[0])

--- a/src/dll/fuse/fuse.c
+++ b/src/dll/fuse/fuse.c
@@ -360,12 +360,11 @@ static int fsp_fuse_core_opt_proc(void *opt_data0, const char *arg, int key,
         else if ('F' == arg[2])
             arg += sizeof "--FileSystemName=" - 1;
         if (0 == MultiByteToWideChar(CP_UTF8, 0, arg, -1,
-            opt_data->VolumeParams.FileSystemName + 5,
-            sizeof opt_data->VolumeParams.FileSystemName / sizeof(WCHAR) - 5))
+            opt_data->VolumeParams.FileSystemName,
+            sizeof opt_data->VolumeParams.FileSystemName / sizeof(WCHAR)))
             return -1;
         opt_data->VolumeParams.FileSystemName
             [sizeof opt_data->VolumeParams.FileSystemName / sizeof(WCHAR) - 1] = L'\0';
-        memcpy(opt_data->VolumeParams.FileSystemName, L"FUSE-", 5 * sizeof(WCHAR));
         return 0;
     case 'u':
         if ('U' == arg[0])

--- a/src/dll/fuse/fuse.c
+++ b/src/dll/fuse/fuse.c
@@ -360,11 +360,12 @@ static int fsp_fuse_core_opt_proc(void *opt_data0, const char *arg, int key,
         else if ('F' == arg[2])
             arg += sizeof "--FileSystemName=" - 1;
         if (0 == MultiByteToWideChar(CP_UTF8, 0, arg, -1,
-            opt_data->VolumeParams.FileSystemName,
-            sizeof opt_data->VolumeParams.FileSystemName / sizeof(WCHAR)))
+            opt_data->VolumeParams.FileSystemName + 5,
+            sizeof opt_data->VolumeParams.FileSystemName / sizeof(WCHAR) - 5))
             return -1;
         opt_data->VolumeParams.FileSystemName
             [sizeof opt_data->VolumeParams.FileSystemName / sizeof(WCHAR) - 1] = L'\0';
+        memcpy(opt_data->VolumeParams.FileSystemName, L"FUSE-", 5 * sizeof(WCHAR));
         return 0;
     case 'u':
         if ('U' == arg[0])


### PR DESCRIPTION
This change addresses issue #250 by adding a `-E`/`--ExactFileSystemName` option which sets the visible file system name/type to that specified on the command line. This differs from the `-F`/`--FileSystemName` option in that the latter prepends "FUSE-" to the specified file system name where the former does not.

I considered a `-R`/`--RawFileSystemName`, but given the near-ubiquitous use of `-r`/`-R` to mean "recursive" or similar, I thought it might create confusion and went with the [suggestion](https://github.com/billziss-gh/winfsp/pull/251#issuecomment-536215888) of "E"/"Exact".

----

Before submitting this PR please review this checklist. Ideally all checkmarks should be checked upon submitting. (Use an x inside square brackets like so: [x])

- [x] **Contributing**: You MUST read and be willing to accept the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc). The agreement gives joint copyright interests in your contributions to you and the original WinFsp author. If you have already accepted the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc) you do not need to do so again.
- [x] **Topic branch**: Avoid creating the PR off the master branch of your fork. Consider creating a topic branch and request a pull from that. This allows you to add commits to the master branch of your fork without affecting this PR.
- [x] **No tabs**: Consistently use SPACES everywhere. NO TABS, unless the file format requires it (e.g. Makefile).
- [x] **Style**: Follow the same code style as the rest of the project.
- [ ] **Tests**: Include tests to the extent that it is possible, especially if you add a new feature.
- [x] **Quality**: Your design and code should be of high quality and something that you are proud of.
