### PR TITLE
Fix O_APPEND behavior when interacting with WinFSP from Go

### DIFF
--- a/Contributors.asciidoc
+++ b/Contributors.asciidoc
@@ -56,6 +56,7 @@ CONTRIBUTOR LIST
 |===
 |Ben Rubson                                                     |ben.rubson at gmail.com
 |Bill Zissimopoulos                                             |billziss at navimatics.com
+|Brett Dutro                                                    |brett.dutro at gmail.com
 |Colin Atkinson (Atakama, https://atakama.com)                  |colin at atakama.com
 |Felix Croes                                                    |felix at dworkin.nl
 |Francois Karam (KS2, http://www.ks2.fr)                        |francois.karam at ks2.fr


### PR DESCRIPTION
In Windows, Go clears any write-related flags when O_APPEND is specified. This causes WinFSP to think that any O_APPEND requests are actually read-only. This adds an additional check for the FILE_APPEND_DATA flag so that we can ensure the request is sent with at least O_WRONLY and O_APPEND set.

----

Before submitting this PR please review this checklist. Ideally all checkmarks should be checked upon submitting. (Use an x inside square brackets like so: [x])

- [x] **Contributing**: You MUST read and be willing to accept the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc). The agreement gives joint copyright interests in your contributions to you and the original WinFsp author. If you have already accepted the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc) you do not need to do so again.
- [x] **Topic branch**: Avoid creating the PR off the master branch of your fork. Consider creating a topic branch and request a pull from that. This allows you to add commits to the master branch of your fork without affecting this PR.
- [x] **No tabs**: Consistently use SPACES everywhere. NO TABS, unless the file format requires it (e.g. Makefile).
- [x] **Style**: Follow the same code style as the rest of the project.
- [x] **Tests**: Include tests to the extent that it is possible, especially if you add a new feature.
- [x] **Quality**: Your design and code should be of high quality and something that you are proud of.
