### PR TITLE
dll: open as directory when file's parent directory should be opened.

### DIFF
--- a/Contributors.asciidoc
+++ b/Contributors.asciidoc
@@ -61,6 +61,7 @@ CONTRIBUTOR LIST
 |Felix Croes                                                    |felix at dworkin.nl
 |Francois Karam (KS2, http://www.ks2.fr)                        |francois.karam at ks2.fr
 |Fritz Elfert                                                   |fritz-github at fritz-elfert.de
+|Gal Hammer (Red Hat, https://www.redhat.com)                   |ghammer at redhat.com
 |John Oberschelp                                                |john at oberschelp.net
 |John Tyner                                                     |jtyner at gmail.com
 |Sam Kelly (DuroSoft Technologies LLC, https://durosoft.com)    |sam at durosoft.com

--- a/src/dll/fsop.c
+++ b/src/dll/fsop.c
@@ -763,6 +763,7 @@ static NTSTATUS FspFileSystemOpCreate_FileOpenTargetDirectory(FSP_FILE_SYSTEM *F
     UINT32 GrantedAccess;
     FSP_FSCTL_TRANSACT_FULL_CONTEXT FullContext;
     FSP_FSCTL_OPEN_FILE_INFO OpenFileInfo;
+    UINT32 CreateOptions;
     UINT32 Information;
 
     Result = FspFileSystemOpenTargetDirectoryCheck(FileSystem, Request, Response, &GrantedAccess);
@@ -775,8 +776,11 @@ static NTSTATUS FspFileSystemOpCreate_FileOpenTargetDirectory(FSP_FILE_SYSTEM *F
     OpenFileInfo.NormalizedName = (PVOID)Response->Buffer;
     OpenFileInfo.NormalizedNameSize = FSP_FSCTL_TRANSACT_RSP_BUFFER_SIZEMAX;
     FspPathSuffix((PWSTR)Request->Buffer, &Parent, &Suffix, Root);
+    CreateOptions = Request->Req.Create.CreateOptions;
+    CreateOptions |= FILE_DIRECTORY_FILE;
+    CreateOptions &= ~FILE_NON_DIRECTORY_FILE;
     Result = FileSystem->Interface->Open(FileSystem,
-        Parent, Request->Req.Create.CreateOptions, GrantedAccess,
+        Parent, CreateOptions, GrantedAccess,
         AddrOfFileContext(FullContext), &OpenFileInfo.FileInfo);
     FspPathCombine((PWSTR)Request->Buffer, Suffix);
     if (!NT_SUCCESS(Result))


### PR DESCRIPTION
When doing a rename Windows opens the destination file with the SL_OPEN_TARGET_DIRECTORY flag. Winfsp trims the file name and execute the Open call back with the files' parent but without telling the user that it should open the file as a directory.

----

Before submitting this PR please review this checklist. Ideally all checkmarks should be checked upon submitting. (Use an x inside square brackets like so: [x])

- [x] **Contributing**: You MUST read and be willing to accept the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc). The agreement gives joint copyright interests in your contributions to you and the original WinFsp author. If you have already accepted the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc) you do not need to do so again.
- [x] **Topic branch**: Avoid creating the PR off the master branch of your fork. Consider creating a topic branch and request a pull from that. This allows you to add commits to the master branch of your fork without affecting this PR.
- [x] **No tabs**: Consistently use SPACES everywhere. NO TABS, unless the file format requires it (e.g. Makefile).
- [x] **Style**: Follow the same code style as the rest of the project.
- [-] **Tests**: Include tests to the extent that it is possible, especially if you add a new feature.
- [-] **Quality**: Your design and code should be of high quality and something that you are proud of.
