### PR TITLE
Fixed data corruption when overwriting a file on a Fuse v3 filesystem

### DIFF
--- a/Contributors.asciidoc
+++ b/Contributors.asciidoc
@@ -64,6 +64,7 @@ CONTRIBUTOR LIST
 |Gal Hammer (Red Hat, https://www.redhat.com)                   |ghammer at redhat.com
 |John Oberschelp                                                |john at oberschelp.net
 |John Tyner                                                     |jtyner at gmail.com
+|Pedro Frejo (Arpa System, https://arpasystem.com)              |pedro.frejo at arpasystem.com
 |Sam Kelly (DuroSoft Technologies LLC, https://durosoft.com)    |sam at durosoft.com
 |Santiago Ganis                                                 |sganis at gmail.com
 |Tobias Urlaub                                                  |saibotu at outlook.de

--- a/src/dll/fuse/fuse_intf.c
+++ b/src/dll/fuse/fuse_intf.c
@@ -1030,14 +1030,12 @@ static NTSTATUS fsp_fuse_intf_Open(FSP_FILE_SYSTEM *FileSystem,
          * Some Windows applications (notably Go programs) specify FILE_APPEND_DATA without
          * FILE_WRITE_DATA when opening files for appending. This caused the WinFsp-FUSE layer
          * to erroneously pass O_RDONLY to the FUSE file system in such cases. We add a test
-         * for FILE_APPEND_DATA to ensure that either O_WRONLY or O_RDWR is specified and that
-         * the O_APPEND flag is set.
+         * for FILE_APPEND_DATA to ensure that either O_WRONLY or O_RDWR is specified.
          */
         if (GrantedAccess & FILE_APPEND_DATA)
         {
             if (fi.flags == 0)
                 fi.flags = 1; /* need O_WRONLY as a bare minimum in order to append */
-            fi.flags |= 8/*O_APPEND*/;
         }
 
         if (0 != f->ops.open)


### PR DESCRIPTION
When a file of size "s" is overwritten, forcing "O_APPEND" flag
makes the file offset to be placed "s" bytes in advance.
This caused subsequent write operations to be paded by "s" zeroes,
thus corrupting the file.


----

Before submitting this PR please review this checklist. Ideally all checkmarks should be checked upon submitting. (Use an x inside square brackets like so: [x])

- [x] **Contributing**: You MUST read and be willing to accept the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc). The agreement gives joint copyright interests in your contributions to you and the original WinFsp author. If you have already accepted the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc) you do not need to do so again.
- [x] **Topic branch**: Avoid creating the PR off the master branch of your fork. Consider creating a topic branch and request a pull from that. This allows you to add commits to the master branch of your fork without affecting this PR.
- [x] **No tabs**: Consistently use SPACES everywhere. NO TABS, unless the file format requires it (e.g. Makefile).
- [x] **Style**: Follow the same code style as the rest of the project.
- [x] **Tests**: Include tests to the extent that it is possible, especially if you add a new feature.
- [x] **Quality**: Your design and code should be of high quality and something that you are proud of.
