### PR TITLE
Mute a GCC warning

### DIFF
--- a/inc/fuse/winfsp_fuse.h
+++ b/inc/fuse/winfsp_fuse.h
@@ -360,7 +360,10 @@ static inline int fsp_fuse_set_signal_handlers(void *se)
 
     static sigset_t sigmask;
     static pthread_t sigthr;
-    struct sigaction oldsa, newsa = { 0 };
+    struct sigaction oldsa, newsa;
+
+    # memset instead of ={0} to avoid a GCC -Wmissing-field-initializers warning
+    memset(&newsa, 0, sizeof newsa);
 
     if (0 != se)
     {


### PR DESCRIPTION
Hi,

This PR mutes a GCC `-Wmissing-field-initializers` warning, as explained in #287.
Compiles successfully.
It then closes #287.

Many thanks 👍

----

- [x] **Contributing**: You MUST read and be willing to accept the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc). The agreement gives joint copyright interests in your contributions to you and the original WinFsp author. If you have already accepted the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc) you do not need to do so again.
- [x] **Topic branch**: Avoid creating the PR off the master branch of your fork. Consider creating a topic branch and request a pull from that. This allows you to add commits to the master branch of your fork without affecting this PR.
- [x] **No tabs**: Consistently use SPACES everywhere. NO TABS, unless the file format requires it (e.g. Makefile).
- [x] **Style**: Follow the same code style as the rest of the project.
- [x] **Tests**: Include tests to the extent that it is possible, especially if you add a new feature.
- [x] **Quality**: Your design and code should be of high quality and something that you are proud of.
