### PR TITLE
[WIP] Added buffer for sequential small read

### DIFF
--- a/src/dll/fuse/fuse_intf.c
+++ b/src/dll/fuse/fuse_intf.c
@@ -950,12 +950,12 @@ exit:
             if (CreateOptions & FILE_DIRECTORY_FILE)
             {
                 if (0 != f->ops.releasedir)
-                    f->ops.releasedir(filedesc->PosixPath, &fi);
+                    f->ops.releasedir(contexthdr->PosixPath, &fi);
             }
             else
             {
                 if (0 != f->ops.release)
-                    f->ops.release(filedesc->PosixPath, &fi);
+                    f->ops.release(contexthdr->PosixPath, &fi);
             }
         }
 

--- a/src/sys/driver.h
+++ b/src/sys/driver.h
@@ -1423,6 +1423,11 @@ typedef struct
     /* stream support */
     HANDLE MainFileHandle;
     PFILE_OBJECT MainFileObject;
+    /* readahead */
+    PVOID  Buffer;
+    ULONG  BufferSize;
+    LARGE_INTEGER LastOffset;
+    LARGE_INTEGER BufferOffset;
 } FSP_FILE_DESC;
 NTSTATUS FspFileNodeCopyActiveList(PDEVICE_OBJECT DeviceObject,
     FSP_FILE_NODE ***PFileNodes, PULONG PFileNodeCount);

--- a/src/sys/file.c
+++ b/src/sys/file.c
@@ -2283,6 +2283,10 @@ VOID FspFileDescDelete(FSP_FILE_DESC *FileDesc)
 {
     PAGED_CODE();
 
+    if (0 != FileDesc->Buffer) {
+        FspFree(FileDesc->Buffer);
+    }
+
     FspMainFileClose(FileDesc->MainFileHandle, FileDesc->MainFileObject);
 
     if (0 != FileDesc->DirectoryPattern.Buffer &&


### PR DESCRIPTION
For sequential small read (4K), the overhead of switching between kernel and usermode hurts performance, for example, performance of reading with 4K is only 1/3 of reading with 64K (40MB/s vs 120MB/s). 

This PR try to improve performance of sequential small read by adding a read-ahead buffer (64KB). 

BUT this patch did not work, there is a problem when we copy data from the readahead buffer to user buffer. I don't know much on how windows kernel manage memory, so I'm sending this PR to ask for help.

----

Before submitting this PR please review this checklist. Ideally all checkmarks should be checked upon submitting. (Use an x inside square brackets like so: [x])

- [x] **Contributing**: You MUST read and be willing to accept the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc). The agreement gives joint copyright interests in your contributions to you and the original WinFsp author. If you have already accepted the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc) you do not need to do so again.
- [x] **Topic branch**: Avoid creating the PR off the master branch of your fork. Consider creating a topic branch and request a pull from that. This allows you to add commits to the master branch of your fork without affecting this PR.
- [x] **No tabs**: Consistently use SPACES everywhere. NO TABS, unless the file format requires it (e.g. Makefile).
- [x] **Style**: Follow the same code style as the rest of the project.
- [ ] **Tests**: Include tests to the extent that it is possible, especially if you add a new feature.
- [ ] **Quality**: Your design and code should be of high quality and something that you are proud of.
