### PR TITLE
Document the NotifyInfo fields for the .NET interop layer.

### DIFF
--- a/Contributors.asciidoc
+++ b/Contributors.asciidoc
@@ -54,6 +54,7 @@ This CONTRIBUTOR AGREEMENT applies to any contribution that you make to the WinF
 CONTRIBUTOR LIST
 ----------------
 |===
+|Alberto Alonso                                                 |alberto at alonso.xyz
 |Ben Rubson                                                     |ben.rubson at gmail.com
 |Bill Zissimopoulos                                             |billziss at navimatics.com
 |Brett Dutro                                                    |brett.dutro at gmail.com

--- a/src/dotnet/Interop.cs
+++ b/src/dotnet/Interop.cs
@@ -342,17 +342,17 @@ namespace Fsp.Interop
     /// </summary>
     public enum NotifyInfoAction : UInt32
     {
-        FileActionAdded = 1,
-        FileActionRemoved = 2,
-        FileActionModified = 3,
-        FileActionRenamedOldName = 4,
-        FileActionRenamedNewName = 5,
-        FileActionAddedStream = 6,
-        FileActionRemovedStream = 7,
-        FileActionModifiedStream = 8,
-        FileActionRemovedByDelete = 9,
-        FileActionIdNotTunnelled = 10,
-        FileActionTunnelledIdCollision = 11,
+        Added = 1,
+        Removed = 2,
+        Modified = 3,
+        RenamedOldName = 4,
+        RenamedNewName = 5,
+        AddedStream = 6,
+        RemovedStream = 7,
+        ModifiedStream = 8,
+        RemovedByDelete = 9,
+        IdNotTunnelled = 10,
+        TunnelledIdCollision = 11,
     }
 
 
@@ -362,20 +362,20 @@ namespace Fsp.Interop
     [Flags]
     public enum NotifyInfoFilter : UInt32
     {
-        FileNotifyNone              = 0x00000,
-        FileNotifyChangeFileName    = 0x00001,
-        FileNotifyChangeDirName     = 0x00002,
-        FileNotifyChangeName        = FileNotifyChangeFileName | FileNotifyChangeDirName,
-        FileNotifyChangeAttributes  = 0x00004,
-        FileNotifyChangeSize        = 0x00008,
-        FileNotifyChangeLastWrite   = 0x00010,
-        FileNotifyChangeLastAccess  = 0x00020,
-        FileNotifyChangeCreation    = 0x00040,
-        FileNotifyChangeEa          = 0x00080,
-        FileNotifyChangeSecurity    = 0x00100,
-        FileNotifyChangeStreamName  = 0x00200,
-        FileNotifyChangeStreamSize  = 0x00400,
-        FileNotifyChangeStreamWrite = 0x00800,
+        None              = 0x00000,
+        ChangeFileName    = 0x00001,
+        ChangeDirName     = 0x00002,
+        ChangeName        = ChangeFileName | ChangeDirName,
+        ChangeAttributes  = 0x00004,
+        ChangeSize        = 0x00008,
+        ChangeLastWrite   = 0x00010,
+        ChangeLastAccess  = 0x00020,
+        ChangeCreation    = 0x00040,
+        ChangeEa          = 0x00080,
+        ChangeSecurity    = 0x00100,
+        ChangeStreamName  = 0x00200,
+        ChangeStreamSize  = 0x00400,
+        ChangeStreamWrite = 0x00800,
     }
 
     /// <summary>

--- a/src/dotnet/Interop.cs
+++ b/src/dotnet/Interop.cs
@@ -338,14 +338,55 @@ namespace Fsp.Interop
     }
 
     /// <summary>
+    /// Enumeration of all the possible values for NotifyInfo.Action
+    /// </summary>
+    public enum NotifyInfoAction : UInt32
+    {
+        FileActionAdded = 1,
+        FileActionRemoved = 2,
+        FileActionModified = 3,
+        FileActionRenamedOldName = 4,
+        FileActionRenamedNewName = 5,
+        FileActionAddedStream = 6,
+        FileActionRemovedStream = 7,
+        FileActionModifiedStream = 8,
+        FileActionRemovedByDelete = 9,
+        FileActionIdNotTunnelled = 10,
+        FileActionTunnelledIdCollision = 11,
+    }
+
+
+    /// <summary>
+    /// Enumeration of all the possible values for NotifyInfo.Filter
+    /// </summary>
+    [Flags]
+    public enum NotifyInfoFilter : UInt32
+    {
+        FileNotifyNone              = 0x00000,
+        FileNotifyChangeFileName    = 0x00001,
+        FileNotifyChangeDirName     = 0x00002,
+        FileNotifyChangeName        = FileNotifyChangeFileName | FileNotifyChangeDirName,
+        FileNotifyChangeAttributes  = 0x00004,
+        FileNotifyChangeSize        = 0x00008,
+        FileNotifyChangeLastWrite   = 0x00010,
+        FileNotifyChangeLastAccess  = 0x00020,
+        FileNotifyChangeCreation    = 0x00040,
+        FileNotifyChangeEa          = 0x00080,
+        FileNotifyChangeSecurity    = 0x00100,
+        FileNotifyChangeStreamName  = 0x00200,
+        FileNotifyChangeStreamSize  = 0x00400,
+        FileNotifyChangeStreamWrite = 0x00800,
+    }
+
+    /// <summary>
     /// Contains file change notification information.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public struct NotifyInfo
     {
         public String FileName;
-        public UInt32 Action;
-        public UInt32 Filter;
+        public NotifyInfoAction Action;
+        public NotifyInfoFilter Filter;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -1158,8 +1199,8 @@ namespace Fsp.Interop
                 for (int I = 0; NotifyInfoArray.Length > I; I++)
                 {
                     NotifyInfoInternal Internal = default(NotifyInfoInternal);
-                    Internal.Action = NotifyInfoArray[I].Action;
-                    Internal.Filter = NotifyInfoArray[I].Filter;
+                    Internal.Action = (UInt32)NotifyInfoArray[I].Action;
+                    Internal.Filter = (UInt32)NotifyInfoArray[I].Filter;
                     Internal.SetFileNameBuf(NotifyInfoArray[I].FileName);
                     FspFileSystemAddNotifyInfo(
                         ref Internal, (IntPtr)P, (UInt32)Length, out BytesTransferred);


### PR DESCRIPTION
The .NET interface for `FileSystemHost.Notify` expects an Action field and Filter field declared as UInt32, making it very cryptic to find out what the values should be. Moreover, the documentation for this can only be found in some issue discussion in the bug tracker.

Added two enumerations that list the possible values for these fields.


