### PR TITLE
Fix an alignment problem in the FspFileSystemNotify interop

### DIFF
--- a/src/dotnet/Interop.cs
+++ b/src/dotnet/Interop.cs
@@ -1188,10 +1188,11 @@ namespace Fsp.Interop
             int Length = 0;
             for (int I = 0; NotifyInfoArray.Length > I; I++)
             {
-                Length = (Length + 7) & ~7; // align to next qword boundary
                 Length += NotifyInfoInternal.FileNameBufOffset +
                     NotifyInfoArray[I].FileName.Length * 2;
+                Length = (Length + 7) & ~7; // align to next qword boundary
             }
+
             Byte[] Buffer = new Byte[Length];
             UInt32 BytesTransferred = default(UInt32);
             fixed (Byte *P = Buffer)


### PR DESCRIPTION
Fix an alignment problem in the FspFileSystemNotify interop that would leave a buffer size not aligned to a multiple of 8, and make notify calls fail.
