### PR TITLE
Credential: Default do not save password

### DIFF
--- a/Contributors.asciidoc
+++ b/Contributors.asciidoc
@@ -69,4 +69,5 @@ CONTRIBUTOR LIST
 |Sam Kelly (DuroSoft Technologies LLC, https://durosoft.com)    |sam at durosoft.com
 |Santiago Ganis                                                 |sganis at gmail.com
 |Tobias Urlaub                                                  |saibotu at outlook.de
+|Victor Gao                                                     |victgm at outlook.com
 |===

--- a/src/dll/np.c
+++ b/src/dll/np.c
@@ -742,7 +742,7 @@ DWORD APIENTRY NPAddConnection3(HWND hwndOwner,
     DWORD AuthPackage, CredentialsKind;
     WCHAR UserName[CREDUI_MAX_USERNAME_LENGTH + 1], Password[CREDUI_MAX_PASSWORD_LENGTH + 1];
 #if defined(FSP_NP_CREDENTIAL_MANAGER)
-    BOOL Save = TRUE;
+    BOOL Save = FALSE;
 #endif
 
     //dwFlags |= CONNECT_INTERACTIVE | CONNECT_PROMPT; /* TESTING ONLY! */


### PR DESCRIPTION
If user want to save password, click save and credential window won't appear again.
Do not remember password should be default option.
#280 