### PR TITLE
inc: don't redeclare _FILE_FULL_EA_INFORMATION for mingw

### DIFF
--- a/Contributors.asciidoc
+++ b/Contributors.asciidoc
@@ -65,6 +65,7 @@ CONTRIBUTOR LIST
 |Gal Hammer (Red Hat, https://www.redhat.com)                   |ghammer at redhat.com
 |John Oberschelp                                                |john at oberschelp.net
 |John Tyner                                                     |jtyner at gmail.com
+|Paweł Wegner (Google LLC, https://google.com)                  |lemourin at google.com
 |Pedro Frejo (Arpa System, https://arpasystem.com)              |pedro.frejo at arpasystem.com
 |Sam Kelly (DuroSoft Technologies LLC, https://durosoft.com)    |sam at durosoft.com
 |Santiago Ganis                                                 |sganis at gmail.com

--- a/inc/winfsp/winfsp.h
+++ b/inc/winfsp/winfsp.h
@@ -91,6 +91,7 @@ typedef struct _REPARSE_DATA_BUFFER
 #if !defined(FILE_NEED_EA)
 #define FILE_NEED_EA                    0x00000080
 #endif
+#if !defined(__MINGW32__)
 typedef struct _FILE_FULL_EA_INFORMATION
 {
     ULONG NextEntryOffset;
@@ -99,6 +100,7 @@ typedef struct _FILE_FULL_EA_INFORMATION
     USHORT EaValueLength;
     CHAR EaName[1];
 } FILE_FULL_EA_INFORMATION, *PFILE_FULL_EA_INFORMATION;
+#endif
 
 /**
  * @group File System


### PR DESCRIPTION
mingw-w64 declares _FILE_FULL_EA_INFORMATION since Jan 18, 2010 [1].

The change allows the winfsp client library to be consumed by projects built with mingw.

[1]: https://github.com/mirror/mingw-w64/commit/afd1465722e7c116d9f55718551fe544cf57edd6

(Enter your PR description here.)

----

Before submitting this PR please review this checklist. Ideally all checkmarks should be checked upon submitting. (Use an x inside square brackets like so: [x])

- [x] **Contributing**: You MUST read and be willing to accept the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc). The agreement gives joint copyright interests in your contributions to you and the original WinFsp author. If you have already accepted the [CONTRIBUTOR AGREEMENT](https://github.com/billziss-gh/winfsp/blob/master/Contributors.asciidoc) you do not need to do so again.
- [x] **Topic branch**: Avoid creating the PR off the master branch of your fork. Consider creating a topic branch and request a pull from that. This allows you to add commits to the master branch of your fork without affecting this PR.
- [x] **No tabs**: Consistently use SPACES everywhere. NO TABS, unless the file format requires it (e.g. Makefile).
- [x] **Style**: Follow the same code style as the rest of the project.
- [x] **Tests**: Include tests to the extent that it is possible, especially if you add a new feature.
- [x] **Quality**: Your design and code should be of high quality and something that you are proud of.
