### PR TITLE
dll: add support for disabling directio.

### DIFF
--- a/src/dll/fuse/fuse_intf.c
+++ b/src/dll/fuse/fuse_intf.c
@@ -1047,9 +1047,6 @@ static NTSTATUS fsp_fuse_intf_Create(FSP_FILE_SYSTEM *FileSystem,
 
     /*
      * Ignore fuse_file_info::keep_cache.
-     * NOTE: Originally WinFsp did not support disabling the cache manager
-     * for an individual file. This is now possible and we should revisit.
-     *
      * Ignore fuse_file_info::nonseekable.
      */
 
@@ -1194,9 +1191,6 @@ static NTSTATUS fsp_fuse_intf_Open(FSP_FILE_SYSTEM *FileSystem,
 
     /*
      * Ignore fuse_file_info::keep_cache.
-     * NOTE: Originally WinFsp did not support disabling the cache manager
-     * for an individual file. This is now possible and we should revisit.
-     *
      * Ignore fuse_file_info::nonseekable.
      */
 


### PR DESCRIPTION
fix #615 

After setting the fuse.directio flag in cgofuse lib, I think the only thing left is to pass this flag to IRP_CREATE.Rsp.Create.Opened.DisableCache. To achieve that, I expanded the OPEN interface to accept a DisableCache pointer in this PR. 

Another approach I considered is changing the parameter type from `FSP_FSCTL_FILE_INFO *FileInfo` to `FSP_FSCTL_OPEN_FILE_INFO *`, and then adding a `DisableCache` field into the `FSP_FSCTL_OPEN_FILE_INFO` struct.

Both methods seem fine to me. Do you think there is a better solution, or is there something I might have overlooked?

----

Before submitting this PR please review this checklist. Ideally all checkmarks should be checked upon submitting. (Use an x inside square brackets like so: [x])

- [x] **Contributing**: You MUST read and be willing to accept the [CONTRIBUTOR AGREEMENT](https://github.com/winfsp/winfsp/blob/master/Contributors.asciidoc). The agreement gives joint copyright interests in your contributions to you and the original WinFsp author. If you have already accepted the [CONTRIBUTOR AGREEMENT](https://github.com/winfsp/winfsp/blob/master/Contributors.asciidoc) you do not need to do so again.
- [x] **Topic branch**: Avoid creating the PR off the master branch of your fork. Consider creating a topic branch and request a pull from that. This allows you to add commits to the master branch of your fork without affecting this PR.
- [x] **No tabs**: Consistently use SPACES everywhere. NO TABS, unless the file format requires it (e.g. Makefile).
- [x] **Style**: Follow the same code style as the rest of the project.
- [x] **Tests**: Include tests to the extent that it is possible, especially if you add a new feature.
- [x] **Quality**: Your design and code should be of high quality and something that you are proud of.
