### PR TITLE
dll & fuse: Added "AddWriteEaPerm" mount option.

### DIFF
--- a/src/dll/fuse/fuse.c
+++ b/src/dll/fuse/fuse.c
@@ -119,6 +119,8 @@ static struct fuse_opt fsp_fuse_core_opts[] =
     FUSE_OPT_KEY("GroupName=", 'g'),
     FSP_FUSE_CORE_OPT("--GroupName=", set_gid, 1),
     FUSE_OPT_KEY("--GroupName=", 'g'),
+    
+    FSP_FUSE_CORE_OPT("AddWriteEaAccess", add_write_ea_access, 1),
 
     FUSE_OPT_END,
 };
@@ -902,6 +904,7 @@ FSP_FUSE_API struct fuse *fsp_fuse_new(struct fsp_fuse_env *env,
     f->set_create_dir_umask = opt_data.set_create_dir_umask; f->create_dir_umask = opt_data.create_dir_umask;
     f->set_uid = opt_data.set_uid; f->uid = opt_data.uid;
     f->set_gid = opt_data.set_gid; f->gid = opt_data.gid;
+    f->add_write_ea_access = opt_data.add_write_ea_access;
     f->rellinks = opt_data.rellinks;
     f->dothidden = opt_data.dothidden;
     f->ThreadCount = opt_data.ThreadCount;

--- a/src/dll/fuse/library.h
+++ b/src/dll/fuse/library.h
@@ -55,6 +55,7 @@ struct fuse
     int set_create_dir_umask, create_dir_umask;
     int set_uid, uid;
     int set_gid, gid;
+    int add_write_ea_access;
     int rellinks;
     int dothidden;
     unsigned ThreadCount;
@@ -147,6 +148,7 @@ struct fsp_fuse_core_opt_data
         set_create_dir_umask, create_dir_umask,
         set_uid, uid, username_to_uid_result,
         set_gid, gid,
+        add_write_ea_access,
         set_uidmap,
         set_attr_timeout, attr_timeout,
         rellinks,


### PR DESCRIPTION
## Description 

Following the discussion in PR #610, this PR attempts to add a per-mount ```AddWriteEaPerm``` FUSE option. When enabled, it modifies the security descriptor to add FILE_WRITE_EA permission to ACEs that already have FILE_WRITE_DATA, no matter the ACE type is allow or deny.

## Testing
I've done some basic testing with the option enabled and disabled, and it appears to address the issue described in #604 while maintaining backward compatibility. However, more thorough testing and review would be appreciated.

---

Fixes #604
Supersedes #610

Thanks for reviewing. Please let me know if I've misunderstood anything or if there are improvements to be made.


----

Before submitting this PR please review this checklist. Ideally all checkmarks should be checked upon submitting. (Use an x inside square brackets like so: [x])

- [x] **Contributing**: You MUST read and be willing to accept the [CONTRIBUTOR AGREEMENT](https://github.com/winfsp/winfsp/blob/master/Contributors.asciidoc). The agreement gives joint copyright interests in your contributions to you and the original WinFsp author. If you have already accepted the [CONTRIBUTOR AGREEMENT](https://github.com/winfsp/winfsp/blob/master/Contributors.asciidoc) you do not need to do so again.
- [x] **Topic branch**: Avoid creating the PR off the master branch of your fork. Consider creating a topic branch and request a pull from that. This allows you to add commits to the master branch of your fork without affecting this PR.
- [x] **No tabs**: Consistently use SPACES everywhere. NO TABS, unless the file format requires it (e.g. Makefile).
- [x] **Style**: Follow the same code style as the rest of the project.
- [ ] **Tests**: Include tests to the extent that it is possible, especially if you add a new feature.
- [x] **Quality**: Your design and code should be of high quality and something that you are proud of.
