### PR TITLE
Appveyor: Add Visual Studio 2022

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
   # Disable the winfsp-tests built-in exception filter to allow WER to collect dumps.
   WINFSP_TESTS_EXCEPTION_FILTER_DISABLE: 1
 
-  matrix:
+  matrix:  # https://www.appveyor.com/docs/windows-images-software/
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
     CONFIGURATION: Debug
     TESTING: Func
@@ -27,6 +27,10 @@ environment:
     TESTING: Func
     DOCKER_TESTING: None
   - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    CONFIGURATION: Release
+    TESTING: Func
+    DOCKER_TESTING: Func
+  - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
     CONFIGURATION: Release
     TESTING: Func
     DOCKER_TESTING: Func


### PR DESCRIPTION
[Appveyor: Add Visual Studio 2022](https://www.appveyor.com/docs/windows-images-software)

Given the slowness of Appveyor testing, should we drop support for EOL versions of Visual Studio?
Should we move the testing over to GitHub Actions?

----

Before submitting this PR please review this checklist. Ideally all checkmarks should be checked upon submitting. (Use an x inside square brackets like so: [x])

- [x] **Contributing**: You MUST read and be willing to accept the [CONTRIBUTOR AGREEMENT](https://github.com/winfsp/winfsp/blob/master/Contributors.asciidoc). The agreement gives joint copyright interests in your contributions to you and the original WinFsp author. If you have already accepted the [CONTRIBUTOR AGREEMENT](https://github.com/winfsp/winfsp/blob/master/Contributors.asciidoc) you do not need to do so again.
- [x] **Topic branch**: Avoid creating the PR off the master branch of your fork. Consider creating a topic branch and request a pull from that. This allows you to add commits to the master branch of your fork without affecting this PR.
- [x] **No tabs**: Consistently use SPACES everywhere. NO TABS, unless the file format requires it (e.g. Makefile).
- [x] **Style**: Follow the same code style as the rest of the project.
- [x] **Tests**: Include tests to the extent that it is possible, especially if you add a new feature.
- [x] **Quality**: Your design and code should be of high quality and something that you are proud of.
