### PR TITLE
sys: fix FileRenameResource self-deadlock between notify session and FspVolumeNotifyWork

### DIFF
--- a/Contributors.asciidoc
+++ b/Contributors.asciidoc
@@ -74,6 +74,7 @@ CONTRIBUTOR LIST
 |Ronny Chan                                                     |ronny at ronnychan.ca
 |Sam Kelly (DuroSoft Technologies LLC, https://durosoft.com)    |sam at durosoft.com
 |Santiago Ganis                                                 |sganis at gmail.com
+|Seunghoon Yeon (Bdrive Inc, https://www.bdrive.com)            |ysh at bdrive.com
 |Thomas Gibson-Robinson                                         |tom at cocotec.io
 |Tobias Urlaub                                                  |saibotu at outlook.de
 |Victor Gao                                                     |victgm at outlook.com

--- a/src/sys/driver.h
+++ b/src/sys/driver.h
@@ -1363,6 +1363,24 @@ BOOLEAN FspFsvolDeviceFileRenameTryAcquireExclusive(PDEVICE_OBJECT DeviceObject)
     return ExAcquireResourceExclusiveLite(&FsvolDeviceExtension->FileRenameResource, FALSE);
 }
 static inline
+VOID FspFsvolDeviceFileRenameAcquireSharedStarveExclusive(PDEVICE_OBJECT DeviceObject)
+{
+    /*
+     * Acquire the file rename resource shared, but starve (ignore) any QUEUED
+     * exclusive waiter. Used by FspVolumeNotifyWork: a notify session opened by
+     * FspFileSystemNotifyBegin already holds this resource shared (via owner
+     * pointer) and intentionally defers renames until FspFileSystemNotifyEnd. A
+     * plain ExAcquireResourceSharedLite here would honor a concurrently queued
+     * exclusive rename waiter and block -- but the very work item that blocks is
+     * the one that must run FspFileSystemNotifyEnd processing to release the
+     * session and let that rename proceed, so the two self-deadlock. Starving the
+     * queued exclusive waiter is safe: the rename stays blocked behind the shared
+     * holders either way, so name stability across the notify is preserved.
+     */
+    FSP_FSVOL_DEVICE_EXTENSION *FsvolDeviceExtension = FspFsvolDeviceExtension(DeviceObject);
+    ExAcquireSharedStarveExclusive(&FsvolDeviceExtension->FileRenameResource, TRUE);
+}
+static inline
 VOID FspFsvolDeviceFileRenameSetOwner(PDEVICE_OBJECT DeviceObject, PVOID Owner)
 {
     FSP_FSVOL_DEVICE_EXTENSION *FsvolDeviceExtension = FspFsvolDeviceExtension(DeviceObject);

--- a/src/sys/volume.c
+++ b/src/sys/volume.c
@@ -1499,7 +1499,15 @@ static VOID FspVolumeNotifyWork(PVOID NotifyWorkItem0)
     BOOLEAN Unlock = FALSE;
     NTSTATUS Result;
 
-    FspFsvolDeviceFileRenameAcquireShared(FsvolDeviceObject);
+    /*
+     * Starve queued exclusive (rename) waiters here to avoid a self-deadlock:
+     * the enclosing FspFileSystemNotifyBegin/End session already holds this
+     * resource shared, and a rename that queues exclusive mid-session would
+     * otherwise block this work item -- the same work item that must release
+     * the session (FspVolumeNotifyLock count) and unblock that rename. See
+     * FspFsvolDeviceFileRenameAcquireSharedStarveExclusive.
+     */
+    FspFsvolDeviceFileRenameAcquireSharedStarveExclusive(FsvolDeviceObject);
 
     /* iterate over notify information and invalidate/notify each file */
     for (; (PUINT8)NotifyInfo + sizeof(NotifyInfo->Size) <= NotifyInfoEnd;


### PR DESCRIPTION
### Problem

Under heavy concurrent **rename + change-notification** load a volume can deadlock permanently: every rename (exclusive) and every open (shared) on the volume blocks, freezing all access to the mount. It does not recover on its own.

### Root cause

`FspFileSystemNotifyBegin` (`FspVolumeNotifyLock`) acquires the per-volume `FileRenameResource` **shared** via an owner pointer (`&VolumeNotifyCount`) and holds it for the whole `Begin`/`End` session.

If a rename queues as an **exclusive** waiter mid-session, the asynchronous `FspVolumeNotifyWork` then re-acquires the same resource **shared** with `ExAcquireResourceSharedLite` (`src/sys/volume.c`). Because of ERESOURCE writer-priority, that shared acquire blocks behind the queued exclusive waiter — the worker thread is not recognized as the owner, since the owner is the `&VolumeNotifyCount` pointer set by a different thread.

But that work item is the one that must process `FspFileSystemNotifyEnd` (the sentinel record) to drop `VolumeNotifyCount` to 0 and release the session. So it can never run: the session lock is never released, the rename waits forever, and `VolumeNotifyCount` runs away as `Begin` keeps incrementing it.

Diagnosed from a live kernel dump:
- `FileRenameResource`: `ActiveCount=1`, owner = `&VolumeNotifyCount`, `NumberOfExclusiveWaiters=1`, thousands of shared waiters.
- `VolumeNotifyCount` far above 1 (runaway).
- Many system worker threads blocked at `ExAcquireResourceSharedLite ← FspVolumeNotifyWork`.
- User-mode file system idle (IOQ empty) — purely a kernel ERESOURCE deadlock.

Reproduced against WinFsp 2.1 and present on `master` (the notify path is unchanged since the 2022 `FspVolumeNotifyWork: always acquire the rename lock shared` / `allow multiple outstanding calls to FspFileSystemNotifyBegin` commits). It is rarely hit because it needs a file system that issues `Begin`/`Notify`/`End` brackets *and* generates enough concurrent rename load for a rename to queue exclusive inside the bracket.

### Fix

Acquire the rename resource in `FspVolumeNotifyWork` with **`ExAcquireSharedStarveExclusive`** instead of `ExAcquireResourceSharedLite` (added as a small inline helper `FspFsvolDeviceFileRenameAcquireSharedStarveExclusive`).

This is safe: the enclosing `Begin`/`End` session already holds the resource shared and already defers renames until `End`, so granting this (redundant) shared acquire ahead of the *queued* exclusive waiter preserves the name-stability guarantee while breaking the self-deadlock. A real exclusive *holder* still blocks the starve-exclusive acquire, so correctness is unchanged.

### Testing / status

- `winfsp-x64.sys` builds clean (Release|x64, latest WDK).
- The root cause is confirmed from the kernel dump above; the change is a one-line acquire-semantics fix plus a helper.
- Full disclosure: I have **not** yet runtime-validated the patched (test-signed) driver under the workload — that validation is pending. Happy to add results, or to adjust the approach (e.g. drop the redundant re-acquire entirely) if you prefer.
