### PR TITLE
sys: non-blocking CcCanIWrite in FspFsvolWriteCached to avoid FileNode self-deadlock

### DIFF
--- a/src/sys/write.c
+++ b/src/sys/write.c
@@ -305,8 +305,13 @@ static NTSTATUS FspFsvolWriteCached(
         }
     }
 
-    /* should we defer the write? */
-    Success = DEBUGTEST(90) && CcCanIWrite(FileObject, WriteLength, CanWait, Retrying);
+    /* should we defer the write?
+     * 
+     * do not wait while holding exclusive lock on FileNode, if all dirty pages belong to this 
+     * file there is no way to flush them via FspFsvolWriteNonCached, the call will
+     * hang on lock acquisition
+     */
+    Success = DEBUGTEST(90) && CcCanIWrite(FileObject, WriteLength, FALSE, Retrying);
     if (!Success)
     {
         Result = FspWqCreateIrpWorkItem(Irp, FspFsvolWriteCached, 0);

--- a/tst/winfsp-tests/rdwr-test.c
+++ b/tst/winfsp-tests/rdwr-test.c
@@ -1111,6 +1111,58 @@ void rdwr_mixed_test(void)
     }
 }
 
+static void rdwr_copy_large_file_dotest(PWSTR Prefix)
+{
+    HANDLE Handle;
+    WCHAR Source[MAX_PATH], Dest[MAX_PATH], TempPath[MAX_PATH];
+    LARGE_INTEGER FileSize;
+    BOOL Success;
+
+    Success = 0 != GetTempPathW(MAX_PATH, TempPath);
+    ASSERT(Success);
+    StringCbPrintfW(Source, sizeof Source, L"%swinfsp_rdwr_copy_large_file_test_src.bin", TempPath);
+    StringCbPrintfW(Dest, sizeof Dest, L"%s\\winfsp_rdwr_copy_large_file_test_dst.bin", Prefix);
+
+    Handle = CreateFileW(Source,
+        GENERIC_WRITE, FILE_SHARE_READ, 0, CREATE_NEW, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_DELETE_ON_CLOSE, 0);
+    ASSERT(INVALID_HANDLE_VALUE != Handle);
+    
+    FileSize.QuadPart = 5LL * 1024 * 1024 * 1024;
+    Success = SetFilePointerEx(Handle, FileSize, 0, FILE_BEGIN);
+    ASSERT(Success);
+    
+    Success = SetEndOfFile(Handle);
+    ASSERT(Success);
+    
+    Success = CopyFileW(Source, Dest, FALSE);
+    if (Success)
+    {
+        Success = DeleteFileW(Dest);
+        ASSERT(Success);
+    }
+    else
+    {
+        /* out of space: likely memfs */
+        ASSERT(ERROR_DISK_FULL == GetLastError());
+        DeleteFileW(Dest);
+    }
+
+    Success = CloseHandle(Handle);
+    ASSERT(Success);
+}
+
+void rdwr_copy_large_file_test(void)
+{
+    WCHAR DirBuf[MAX_PATH], DriveBuf[3];
+
+    /* memfs would exhaust RAM */
+    if (!OptExternal)
+        return;
+
+    GetTestDirectoryAndDrive(DirBuf, DriveBuf);
+    rdwr_copy_large_file_dotest(DirBuf);
+}
+
 void rdwr_tests(void)
 {
     TEST(rdwr_noncached_test);
@@ -1130,4 +1182,6 @@ void rdwr_tests(void)
     TEST(rdwr_writethru_overlapped_test);
     TEST(rdwr_mmap_test);
     TEST(rdwr_mixed_test);
+    /* Uncomment to run it by hand - against ntptfs */
+    //TEST_OPT(rdwr_copy_large_file_test);
 }


### PR DESCRIPTION
A large buffered copy into a WinFsp volume with kernel caching enabled hangs forever.
Hung process dump, kernel live dump available on request.

The cause seems clear: all dirty pages belong to the same file, while FspFsvolWriteCached is waiting on CcCanIWrite, no other worker can complete page flush bcs FileNode Main resource is held exclusively by that same worker

```
Lock owner:

nt!KeWaitForSingleObject+0x859
nt!CcCanIWrite+0x469
WinFsp!FspFsvolWriteCached
nt!ExpWorkerThread+0x4bb
nt!PspSystemThreadStartup+0x5a
```

```
Waiters 1-7:

nt!ExpWaitForResource+0x72
nt!ExAcquireResourceExclusiveLite+0x5e4
WinFsp!FspFsvolWriteNonCached
nt!ExpWorkerThread+0x4bb
```

```
Waiter 8:

nt!ExpWaitForResource+0x72
nt!ExAcquireResourceExclusiveLite+0x5e4
WinFsp!FspAcquireFileForNtCreateSection
nt!CcWriteBehindPreProcess+0x10d
nt!CcWriteBehindAsync+0x55
nt!CcAsyncLazywriteWorker+0x19e
nt!CcAsyncLazywriteWorkerThread+0x73
nt!ExpWorkerThread+0x4bb
```

Proposed fix is to never do a blocking wait, always defer to a worker if can't write immediatelly.
I couldn't come up with a smarter repro than the one you see. we need to really cross CcDirtyPageThreshold and I can't think of a way to do that without significant resource consumption. Left this test as optional, so you can try it yourself.

----

Before submitting this PR please review this checklist. Ideally all checkmarks should be checked upon submitting. (Use an x inside square brackets like so: [x])

- [x] **Contributing**: You MUST read and be willing to accept the [CONTRIBUTOR AGREEMENT](https://github.com/winfsp/winfsp/blob/master/Contributors.asciidoc). The agreement gives joint copyright interests in your contributions to you and the original WinFsp author. If you have already accepted the [CONTRIBUTOR AGREEMENT](https://github.com/winfsp/winfsp/blob/master/Contributors.asciidoc) you do not need to do so again.
- [x] **Topic branch**: Avoid creating the PR off the master branch of your fork. Consider creating a topic branch and request a pull from that. This allows you to add commits to the master branch of your fork without affecting this PR.
- [x] **No tabs**: Consistently use SPACES everywhere. NO TABS, unless the file format requires it (e.g. Makefile).
- [x] **Style**: Follow the same code style as the rest of the project.
- [x] **Tests**: Include tests to the extent that it is possible, especially if you add a new feature.
- [x] **Quality**: Your design and code should be of high quality and something that you are proud of.
